### PR TITLE
Remove Turbolinks

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -18,9 +18,6 @@ gem 'therubyracer', platforms: :ruby
 # Use jquery as the JavaScript library
 gem 'jquery-rails'
 
-# Turbolinks makes following links in your web application faster. Read more: https://github.com/rails/turbolinks
-gem 'turbolinks'
-
 # Build JSON APIs with ease. Read more: https://github.com/rails/jbuilder
 gem 'jbuilder', '~> 1.2'
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -46,13 +46,6 @@ GEM
       xpath (~> 2.0)
     childprocess (0.3.9)
       ffi (~> 1.0, >= 1.0.11)
-    coffee-rails (4.0.0)
-      coffee-script (>= 2.2.0)
-      railties (>= 4.0.0.beta, < 5.0)
-    coffee-script (2.2.0)
-      coffee-script-source
-      execjs
-    coffee-script-source (1.6.3)
     cucumber (1.2.5)
       builder (>= 2.1.2)
       diff-lcs (>= 1.1.3)
@@ -208,8 +201,6 @@ GEM
     treetop (1.4.15)
       polyglot
       polyglot (>= 0.3.1)
-    turbolinks (1.3.0)
-      coffee-rails
     twitter-bootstrap-rails (2.2.8)
       actionpack (>= 3.1)
       execjs
@@ -254,7 +245,6 @@ DEPENDENCIES
   selenium-webdriver
   spork (~> 1.0rc)
   therubyracer
-  turbolinks
   twitter-bootstrap-rails
   uglifier (>= 1.3.0)
   unicorn

--- a/app/assets/javascripts/application.js
+++ b/app/assets/javascripts/application.js
@@ -13,6 +13,5 @@
 //= require jquery
 //= require jquery_ujs
 //= require twitter/bootstrap
-//= require turbolinks
 //= require janrain.js
 //= require_tree .

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -2,8 +2,8 @@
 <html>
 <head>
   <title>GreenMercury</title>
-  <%= stylesheet_link_tag    "application", media: "all", "data-turbolinks-track" => true %>
-  <%= javascript_include_tag "application", "data-turbolinks-track" => true %>
+  <%= stylesheet_link_tag    "application", media: "all" %>
+  <%= javascript_include_tag "application" %>
   <%= csrf_meta_tags %>
 </head>
 <body>


### PR DESCRIPTION
Based on what I've read, the ecosystem just isn't in a place right now where you can make turbolinks work with 3rd-party JS like the Janrain Capture Widget.

Fixes #26
