### PR TITLE
Use password auth for ubuntu machines [#74]

### DIFF
--- a/UBUNTU_SETUP.md
+++ b/UBUNTU_SETUP.md
@@ -84,7 +84,7 @@ Create And Migrate Databases
 ----------------------------
 Now that you have the dependencies installed, it's time to create the databases for the site. At your terminal run `sudo -u postgres psql postgres`. This will open a Psql prompt, where you'll create a user and a database. Replace `<me>` with your Ubuntu username below:
 ```SQL
-create role <me> with login createdb;
+create role <me> with login createdb password 'hacktehplanit';
 create database green_mercury owner <me>;
 create database green_mercury_test owner <me>;
 commit;

--- a/config/database.yml
+++ b/config/database.yml
@@ -18,6 +18,7 @@ test: &test
   host: localhost
   database: green_mercury_test
   encoding: unicode
+  password: hacktehplanit
   pool: 5
 
 cucumber:

--- a/vagrant/bootstrap.sh
+++ b/vagrant/bootstrap.sh
@@ -10,10 +10,9 @@ echo 'source ~vagrant/.rvm/scripts/rvm && rvm use --install --default 1.9.3' | s
 echo 'source ~/.rvm/scripts/rvm' >> ~vagrant/.bash_profile
 echo 'rvm use 1.9.3' >> ~vagrant/.bash_profile
 
-sudo -u postgres psql postgres -c 'create role vagrant with login createdb'
+sudo -u postgres psql postgres -c "create role vagrant with login createdb password 'hacktehplanit'"
 sudo -u postgres psql postgres -c 'create database green_mercury owner vagrant'
 sudo -u postgres psql postgres -c 'create database green_mercury_test owner vagrant'
-sed -i 's/md5/trust/' /etc/postgresql/9.1/main/pg_hba.conf
 service postgresql restart
 
 ln -s /vagrant ~vagrant/green_mercury


### PR DESCRIPTION
It appears that having a password in database.yml, but not having one
in your postgres user, is fine. So we'll use password auth on ubuntu and
continue using passwordless (which works on Postgres.app installs) on
OSX.
