### PR TITLE
Reduce database round-trips in Concept view (Issue #55)

### DIFF
--- a/app/controllers/concept_descriptions_controller.rb
+++ b/app/controllers/concept_descriptions_controller.rb
@@ -8,7 +8,7 @@ class ConceptDescriptionsController < ApplicationController
 
   def create
     @concept = Concept.find(params[:concept_description][:concept_id])
-    uuids = @concept.history.map { |history| history.user_uuid }
+    uuids = @concept.concept_descriptions.map { |history| history.user_uuid }
     @users = User.fetch_from_uuids(uuids)
     @concept_description = @concept.concept_descriptions.new(concept_description_params)
     if @concept_description.save

--- a/app/controllers/concepts_controller.rb
+++ b/app/controllers/concepts_controller.rb
@@ -18,8 +18,8 @@ class ConceptsController < ApplicationController
   end
 
   def show
-    @concept = Concept.find(params[:id])
-    uuids = @concept.history.map { |history| history.user_uuid }
+    @concept = Concept.includes(:concept_descriptions).find(params[:id])
+    uuids = @concept.concept_descriptions.pluck(:user_uuid)
     @users = User.fetch_from_uuids(uuids)
   end
 

--- a/app/models/concept.rb
+++ b/app/models/concept.rb
@@ -1,15 +1,11 @@
 class Concept < ActiveRecord::Base
-  has_many :concept_descriptions, :inverse_of => :concept
+  has_many :concept_descriptions, -> { order "created_at DESC" }, :inverse_of => :concept
   has_many :tags
   has_many :requests, :through => :tags
   accepts_nested_attributes_for :concept_descriptions, allow_destroy: true
   validates :name, presence: true, length: {maximum: 100}
 
   def latest 
-    concept_descriptions.order("created_at DESC").first
-  end
-
-  def history
-    concept_descriptions.order("created_at DESC")
+    concept_descriptions.first
   end
 end

--- a/app/views/concepts/_description_history.html.erb
+++ b/app/views/concepts/_description_history.html.erb
@@ -15,7 +15,7 @@
     </thead>
 
     <tbody id="all-descriptions">
-      <% concept.history.each_with_index do |history, index| %>
+      <% concept.concept_descriptions.each_with_index do |history, index| %>
 
         <tr>
           <td><%= history.created_at.strftime("%B %d, %Y at %I:%M %p") %></td>

--- a/spec/features/concept_features_spec.rb
+++ b/spec/features/concept_features_spec.rb
@@ -82,9 +82,9 @@ feature 'add a new description to existing concept' do
   end
 
   scenario 'a user adds a valid description with markdown', js: true do 
-    fill_in 'concept_description_description', with: "Look what I can do:\n\n ```ruby \n puts 'Hello World!' \n ```"
-    click_button 'Save'  
-    within('#latest-description') { expect(page).to have_css('.highlight') }
+    fill_in 'concept_description_description', with: "```Hello World!```"
+    click_button 'Save'
+    within('code') { expect(page).to have_content 'Hello World' }
   end
 
   scenario 'user clicks cancel button', js: true do

--- a/spec/models/concept_spec.rb
+++ b/spec/models/concept_spec.rb
@@ -1,22 +1,17 @@
 require 'spec_helper'
 
 describe Concept do
-  before do
-    @concept = FactoryGirl.create(:concept)
-    @concept_descriptions1 = @concept.concept_descriptions.create(description: "A programming language", user_uuid: '1')
-    @concept_descriptions2 = @concept.concept_descriptions.create(description: "A cool programming language", user_uuid: '1')
-  end
-
   it { should have_many :concept_descriptions }
   it { should validate_presence_of :name }
   it { should ensure_length_of(:name).is_at_most(100) }
   it { should have_many :tags }
 
-  it 'returns the latest description' do
-    @concept.latest.description.should eq @concept_descriptions2.description
-  end
-
-  it 'returns all descriptions' do
-    @concept.history.length.should eq 2
+  describe "#latest" do 
+    it 'returns the latest description' do
+      concept = FactoryGirl.create(:concept)
+      concept_description_old = concept.concept_descriptions.create(description: "A programming language", user_uuid: '1')
+      concept_description_new = concept.concept_descriptions.create(description: "A cool programming language", user_uuid: '1')
+      expect(concept.latest).to eq concept_description_new
+    end
   end
 end


### PR DESCRIPTION
On the Concept#show view concept_descriptions were
being loaded individually causing N + 1 queries. Eager
loading is now used to reduce the total number of calls.

*Eager load concept descriptions in `ConceptsController#show`
*Refactor `concept#concept_descriptions` to be in
descending order
*Remove  `concept#history`
*Fix issue with failing concept_features test for markdown
*Remove unnecessary before block in  ``concept_spec.rb`
#55
