### PR TITLE
Silence a deprecation warning

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -21,6 +21,9 @@ module GreenMercury
     # Run "rake -D time" for a list of tasks for finding time zone names. Default is UTC.
     # config.time_zone = 'Central Time (US & Canada)'
 
+    # Raise an exception if an unknown locale is requested.
+    config.i18n.enforce_available_locales = true
+
     # The default locale is :en and all translations from config/locales/*.rb,yml are auto loaded.
     # config.i18n.load_path += Dir[Rails.root.join('my', 'locales', '*.{rb,yml}').to_s]
     # config.i18n.default_locale = :de


### PR DESCRIPTION
I'm not sure why this just now started cropping up but it's an easy
enough fix.

I believe we do want to enforce available locales--if someone is trying
to use the site in an unsupported language, an error page isn't great UX
but neither is just giving them a middle finger, and at least with the
error we get an ExceptionNotification.
